### PR TITLE
Attributes & Certificate Metadata for User Registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "migration:run": "npm run dotenv -- 'if [ \"$NODE_ENV\" = \"production\" ]; then npx typeorm migration:run -d ./dist/config/datasource.js; else npm run typeorm -- migration:run -d ./src/config/datasource.ts; fi'",
     "migration:revert": "npm run dotenv -- 'if [ \"$NODE_ENV\" = \"production\" ]; then npx typeorm migration:revert -d ./dist/config/datasource.js; else npm run typeorm -- migration:revert -d ./src/config/datasource.ts; fi'",
     "migration:show": "npm run dotenv -- 'if [ \"$NODE_ENV\" = \"production\" ]; then npx typeorm migration:show -d ./dist/config/datasource.js; else npm run typeorm -- migration:show -d ./src/config/datasource.ts; fi'",
+    "db:drop": "npm run dotenv -- 'if [ \"$NODE_ENV\" = \"production\" ]; then npx typeorm schema:drop -d ./dist/config/datasource.js; else npm run typeorm -- schema:drop -d ./src/config/datasource.ts; fi'",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -7,6 +7,8 @@ export interface RegisterUserRequestBody {
   username: string;
   orgName: string;
   role: UserRole;
+  certMetadata: string;
+  attr?: string;
 }
 
 export interface RegisterUserResponse {

--- a/src/modules/admin/controller/admin.controller.ts
+++ b/src/modules/admin/controller/admin.controller.ts
@@ -18,7 +18,11 @@ export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
   @Post('/enroll')
-  @ApiOperation({ summary: 'Fetch admin PKI from Blockchain' })
+  @ApiOperation({
+    summary: 'Fetch admin PKI from Blockchain',
+    description:
+      'This Endpoint is only for the super admins to be enrolled on the HLF, so they are synced with the Auth DB. You should NOT use this endpoint for any users other than the ones that were used to bootstrap the HLF network.',
+  })
   @ApiResponse({
     status: 201,
     description: 'Admin PKI is successfully fetched',

--- a/src/modules/admin/dto/admin.dto.ts
+++ b/src/modules/admin/dto/admin.dto.ts
@@ -1,6 +1,6 @@
 import { UserRole } from '@app/modules/users/dto/users.enum';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNotEmpty, IsUUID } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
 
 // POST -> Admin login from Blockchain
 export class AdminLoginRequest {
@@ -39,6 +39,22 @@ export class RegisterUserRequest {
   @IsUUID()
   @IsNotEmpty()
   token: string;
+
+  @ApiProperty({
+    example: 'HOD,Teacher,CS',
+    description:
+      'This defines the attributes the user can forward to any certificate it creates. This is only used if passed with userRole: admin. Clients can not create users',
+  })
+  @IsOptional()
+  attr: string;
+
+  @ApiProperty({ example: 'Computer Science', required: true })
+  @IsNotEmpty()
+  deptName: string;
+
+  @ApiProperty({ example: 'HOD', required: true })
+  @IsNotEmpty()
+  position: string;
 }
 
 export class RegisterUserResponse {

--- a/src/modules/admin/services/admin.service.ts
+++ b/src/modules/admin/services/admin.service.ts
@@ -52,6 +52,8 @@ export class AdminService {
       privateKey: response.privateKey,
       publicKey: response.publicKey,
       userRole: UserRole.Admin,
+      position: 'Super Admin',
+      deptName: 'Admins',
     });
 
     return mapUserToUserDto(savedUser);
@@ -85,6 +87,10 @@ export class AdminService {
       username: user.username,
       orgName: user.orgName,
       role: user.userRole,
+      // certMetadata is added in the user's certificate. It defines the user's rights, and roles on a contract
+      // Fabric expects a comma separated metadata string
+      certMetadata: user.position + ',' + user.deptName,
+      attr: user.attr,
     };
     const response = await this.axiosService.post(
       '/api/v1/auth/signup',
@@ -102,6 +108,8 @@ export class AdminService {
       privateKey: response.privateKey,
       publicKey: response.publicKey,
       userRole: user.userRole,
+      position: user.position,
+      deptName: user.deptName,
     });
 
     // respond with secret

--- a/src/modules/users/controllers/users.controller.ts
+++ b/src/modules/users/controllers/users.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 import { SWAGGER_TAGS } from '@config/swagger/tags';
 import { UsersService } from '../services/users.service';
 import {
+  GetOrgUsersListResponse,
   SigninUserRequest,
   SigninUserResponse,
   UpdatePasswordRequest,
@@ -39,5 +40,20 @@ export class UsersController {
     @Body() body: UpdatePasswordRequest,
   ): Promise<UpdatePasswordResponse> {
     return await this.usersService.updatePassword(body);
+  }
+
+  @Get('/organization/:organization_name')
+  @ApiOperation({
+    summary: 'Fetch all users of an organization',
+    description:
+      'This Endpoint fetches all the users in the organization along with their total count in the DB',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'All users against the specified organization',
+    type: GetOrgUsersListResponse,
+  })
+  async fetchOrgUsers(@Param('organization_name') organization: string) {
+    return await this.usersService.fetchOrgUserList(organization);
   }
 }

--- a/src/modules/users/dto/users.dto.ts
+++ b/src/modules/users/dto/users.dto.ts
@@ -43,6 +43,10 @@ export class SigninUserResponse {
     required: true,
   })
   refreshToken: string;
+
+  @ApiProperty({ example: 'HOD', required: true })
+  @IsNotEmpty()
+  position: string;
 }
 
 export class SigninUserRequest {
@@ -88,6 +92,14 @@ export class CreateUser {
   })
   @IsEnum(UserRole)
   userRole?: UserRole;
+
+  @ApiProperty({ example: 'Computer Science', required: true })
+  @IsNotEmpty()
+  deptName: string;
+
+  @ApiProperty({ example: 'HOD', required: true })
+  @IsNotEmpty()
+  position: string;
 }
 
 export class UserDto {
@@ -131,6 +143,14 @@ export class UserDto {
   })
   @IsUUID()
   id: string;
+
+  @ApiProperty({ example: 'Computer Science', required: true })
+  @IsNotEmpty()
+  deptName: string;
+
+  @ApiProperty({ example: 'HOD', required: true })
+  @IsNotEmpty()
+  position: string;
 }
 
 export class UserPki {
@@ -140,4 +160,20 @@ export class UserPki {
     publicKey: string;
     orgName: string;
   };
+}
+
+// GET -> Users against organization
+
+export class GetOrgUsersListResponse {
+  @ApiProperty({
+    description: 'Array of users',
+    type: [UserDto],
+  })
+  users: UserDto[];
+
+  @ApiProperty({
+    description: 'Total count of users',
+    example: 10,
+  })
+  count: number;
 }

--- a/src/modules/users/dto/users.mapper.ts
+++ b/src/modules/users/dto/users.mapper.ts
@@ -8,5 +8,7 @@ export function mapUserToUserDto(user: User): UserDto {
     publicKey: user.publicKey,
     userRole: user.userRole,
     organization: { id: user.organization.id, name: user.organization.name },
+    deptName: user.deptName,
+    position: user.position,
   };
 }

--- a/src/modules/users/entities/users.entity.ts
+++ b/src/modules/users/entities/users.entity.ts
@@ -11,7 +11,7 @@ import {
 import { UserRole } from '../dto/users.enum';
 import { AuthMapping } from '@app/modules/authMapping/entity/authMapping.entity';
 
-@Entity({ name: 'userss' })
+@Entity({ name: 'users' })
 @Unique(['username', 'organization']) // This ensures that each user within org is unique
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn('uuid')
@@ -34,6 +34,12 @@ export class User extends BaseEntity {
     default: UserRole.Client,
   })
   userRole: UserRole;
+
+  @Column({ name: 'position', nullable: false })
+  position: string;
+
+  @Column({ name: 'dept_name', nullable: false })
+  deptName: string;
 
   @Column({ name: 'recoverable_key', nullable: false })
   recoverableKey: string;

--- a/src/modules/users/services/users.service.ts
+++ b/src/modules/users/services/users.service.ts
@@ -17,6 +17,7 @@ import { AuthMappingService } from '@app/modules/authMapping/services/authMappin
 import { AxiosService } from '@app/modules/shared/axios.service';
 import { OrgsService } from '@app/modules/orgs/services/orgs.service';
 import { envVar } from '@app/config/env/default';
+import { mapUserToUserDto } from '../dto/users.mapper';
 
 const encKey = envVar.server.recoverable_encryption_key;
 @Injectable()
@@ -79,6 +80,8 @@ export class UsersService {
         publicKey: user.publicKey,
         organization: org,
         userRole: user.userRole,
+        position: user.position,
+        deptName: user.deptName,
       }),
     );
   }
@@ -104,7 +107,11 @@ export class UsersService {
       userDb,
     );
 
-    return { token: authMap.authUserUuid, refreshToken: authMap.refreshUuid };
+    return {
+      token: authMap.authUserUuid,
+      refreshToken: authMap.refreshUuid,
+      position: userDb.position,
+    };
   }
 
   async updatePassword(
@@ -132,5 +139,14 @@ export class UsersService {
     );
 
     return { message: strings.PASSWORD_UPDATED };
+  }
+
+  async fetchOrgUserList(orgName: string) {
+    const [userList, count] = await this.usersRepository.findAndCount({
+      where: { organization: { name: orgName } },
+      relations: ['organization'],
+    });
+
+    return { users: userList.map(mapUserToUserDto), count };
   }
 }


### PR DESCRIPTION
# 📝 Description

This PR introduces the User Attributes and User Roles (described by the `deptName`, and `position`) in the user registration process. 
*User Attributes*: These Attributes are consumed by HLF CA to generate certificates for admins giving them the rights to register users with specific roles
*User Roles*: This roles defines the user access level while registering other user identities, and in the deployed contracts.

# ♻️ Change Log

- Users & Admins APIs to include the `position`, `deptName`, and `attr` changes
- Fabric API call to integrate `attr`, and `certMetadata` changes
- User entity to include the newly introduced changes
- Swagger documentation updates

# 🏛️ Architecture

NA

# 🧪 Tests

NA
